### PR TITLE
Fix question parsing

### DIFF
--- a/interviewprep/src/app/api/generate/route.ts
+++ b/interviewprep/src/app/api/generate/route.ts
@@ -31,7 +31,12 @@ export async function POST(req: NextRequest) {
   const raw = completion.choices[0].message?.content ?? '';
   const questions = raw
     .split('\n')
-    .map(q => q.replace(/^[0-9.\\-\\s]+/, '').trim())
+    .map(q =>
+      q
+        // remove leading numbering like "1.", "2)" or "- "
+        .replace(/^\s*\d+[).\-]?\s*/, '')
+        .trim()
+    )
     .filter(Boolean)
     .slice(0, 5);
 


### PR DESCRIPTION
## Summary
- handle more numbering styles in the OpenAI response parser

## Testing
- `npx tsc -p interviewprep/tsconfig.json --noEmit` *(fails: Cannot find modules)*
- `npm run lint` *(fails: next not found)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c7dae5214832ca0cb3ae0d7d06be5